### PR TITLE
Some improvement and bugfix for confidential information features

### DIFF
--- a/.lamvery.yml
+++ b/.lamvery.yml
@@ -9,5 +9,5 @@ configuration:
   timeout: 10
   memory_size: 128
 secret:
-  key: <key-id>
+  key_id: <key-id>
   cipher_texts: {}

--- a/lamvery/__init__.py
+++ b/lamvery/__init__.py
@@ -4,3 +4,6 @@ lamvery
 Yet another deploy tool for AWS Lambda in the virtualenv environment.
 """
 __version__ = '0.3.3'
+
+import lamvery.secret
+secret = lamvery.secret

--- a/lamvery/actions.py
+++ b/lamvery/actions.py
@@ -185,7 +185,7 @@ class EncryptAction(BaseAction):
     def action(self):
         client = self.get_client()
         cipher_text = self.get_client().encrypt(
-            self._config.get_secret().get('key'), self._text)
+            self._config.get_secret().get('key_id'), self._text)
 
         if self._store:
             self._config.store_secret(self._name, cipher_text)

--- a/lamvery/client.py
+++ b/lamvery/client.py
@@ -2,6 +2,7 @@
 
 import boto3
 import botocore
+import base64
 
 class Client:
 
@@ -71,10 +72,10 @@ class Client:
                 Name=alias,
                 FunctionVersion=version)
 
-    def encrypt(self, key, text):
-        res = self._kms.encrypt(KeyId=key, Plaintext=text)
-        return res.get('CiphertextBlob')
+    def encrypt(self, key_id, text):
+        res = self._kms.encrypt(KeyId=key_id, Plaintext=text)
+        return base64.b64encode(res.get('CiphertextBlob'))
 
     def decrypt(self, cipher_text):
-        res = self._kms.decrypt(CiphertextBlob=cipher_text)
+        res = self._kms.decrypt(CiphertextBlob=base64.b64decode(cipher_text))
         return res.get('Plaintext')

--- a/tests/lamvery/client_test.py
+++ b/tests/lamvery/client_test.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import botocore
+import base64
 
 from unittest import TestCase
 from nose.tools import ok_, eq_, raises
@@ -59,8 +60,8 @@ class ClientTestCase(TestCase):
 
     def test_encrypt(self):
         self.client._kms.encrypt = Mock(return_value={'CiphertextBlob': 'foo'})
-        eq_(self.client.encrypt('key', 'val'), 'foo')
+        eq_(self.client.encrypt('key', 'val'), base64.b64encode('foo'))
 
     def test_decrypt(self):
         self.client._kms.decrypt = Mock(return_value={'Plaintext': 'bar'})
-        eq_(self.client.decrypt('secret'), 'bar')
+        eq_(self.client.decrypt(base64.b64encode('secret')), 'bar')


### PR DESCRIPTION
- `secret: key` -> `secret: key_id`
- Simplify importing of lamvery.secret
- Lost jinja2 descriptor when call `encrypt` command with `-s` option