### PR TITLE
single file upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ pip install lamvery
 
 # Setup
 
-At first,
+First,
 
 ```sh
 lamvery init
 ```
 
-And edit your `.lamvery.yml` like this.  
+And then edit your `.lamvery.yml` like so.  
 The configuration is written in YAML syntax with `jinja2` template.  
-And environment variables stored `env` variable.
+Environment variables are stored in the `env` variable.
 
 ```yml
 profile: default
@@ -133,7 +133,7 @@ lamvery invoke [-a <alias>] [-v <version>] path/to/input.json
 ## Options
 
 - `-a` or `--alias`  
-This option needed by `deploy` and `set-alias` and `invoke` commands.  
+This option is needed by the `deploy` and `set-alias` and `invoke` commands.  
 Alias for a version of the function.
 
 - `-c` or `--conf-file`  
@@ -142,32 +142,36 @@ Specify the configuration file.
 default: `.lamvery.yml`
 
 - `-d` or `--dry-run`  
-This option needed by `deploy` and `alias` commands.  
+This option is needed by the `deploy` and `alias` commands.  
 Output the difference of configuration and the alias without updating.
 
+- `-s` or `--single-file`  
+This option is needed by the `archive` and `deploy` command.  
+Archive only the lambda function file, so you can inline edit in the AWS Management Console.
+
 - `-l` or `--no-libs`  
-This option only needed by `deploy` command.  
-Archiving without all libraries.
+This option is needed by the `archive` and `deploy` command.  
+Archive without all libraries.
 
 - `-n` or `--secret-name`  
-This option needed by `encrypt` and `decrypt` commands.  
+This option is needed by the `encrypt` and `decrypt` commands.  
 The name of the secret value.
 
 - `-p` or `--publish`  
-This option only needed by `deploy` command.
+This option is only needed by the `deploy` command.
 Publish the version as an atomic operation.
 
 - `-k` or `--keep-empty-events`  
-This option only needed by `events` command.
+This option is only needed by the `events` command.
 Keep the empty CloudWatch Event Rule that does not have CloudWatch Event Target.
 
 - `-s` or `--store`  
-This option only needed by `encrypt` command.  
+This option is only needed by the `encrypt` command.  
 Store encripted value to configuration file (default: `.lamvery.yml`).  
-This option is required `-n` or `--secret-name` option.
+Requires the `-n` or `--secret-name` option.
 
 - `-v` or `--version`  
-This option needed by `set-alias` and `invoke` commands.  
+This option is needed by the `set-alias` and `invoke` commands.  
 Version of the function.
 
 # Configuration file (.lamvery.yml)

--- a/lamvery/actions/archive.py
+++ b/lamvery/actions/archive.py
@@ -7,15 +7,19 @@ class ArchiveAction(BaseAction):
 
     def __init__(self, args):
         super(ArchiveAction, self).__init__(args)
+        self._single_file = args.single_file
         self._no_libs = args.no_libs
 
     def action(self):
         self._logger.info('Start archiving...')
         archive_name = self._config.get_archive_name()
+        function_filename = self._config.get_function_filename()
         secret = self._config.generate_lambda_secret()
         exclude = self._config.get_exclude()
         archive = Archive(filename=archive_name,
+                          function_filename=function_filename,
                           secret=secret,
+                          single_file=self._single_file,
                           no_libs=self._no_libs,
                           exclude=exclude)
         zipfile = archive.create_zipfile()

--- a/lamvery/actions/deploy.py
+++ b/lamvery/actions/deploy.py
@@ -11,15 +11,19 @@ class DeployAction(ConfigureAction):
         super(DeployAction, self).__init__(args)
         self._publish = args.publish
         self._set_alias = SetAliasAction(args)
+        self._single_file = args.single_file
         self._no_libs = args.no_libs
 
     def action(self):
         self._logger.info('Start deployment...')
         archive_name = self._config.get_archive_name()
+        function_filename = self._config.get_function_filename()
         secret = self._config.generate_lambda_secret()
         exclude = self._config.get_exclude()
         archive = Archive(filename=archive_name,
+                          function_filename=function_filename,
                           secret=secret,
+                          single_file=self._single_file,
                           no_libs=self._no_libs,
                           exclude=exclude)
         func_name   = self._config.get_function_name()

--- a/lamvery/cli.py
+++ b/lamvery/cli.py
@@ -57,6 +57,12 @@ def main():
         'action': 'store_true',
         'default': False
     }
+    sf_args = ('-s', '--single-file',)
+    sf_kwargs = {
+        'help': 'Only use the main lambda function file',
+        'action': 'store_true',
+        'default': False
+    }
     l_args = ('-l', '--no-libs',)
     l_kwargs = {
         'help': 'Archiving without all libraries',
@@ -101,6 +107,7 @@ def main():
         'archive',
         help='Archive your code and libraries to <your-function-name>.zip')
     archive_parser.add_argument(*c_args, **c_kwargs)
+    archive_parser.add_argument(*sf_args, **sf_kwargs)
     archive_parser.add_argument(*l_args, **l_kwargs)
     archive_parser.set_defaults(func=archive)
 
@@ -126,6 +133,7 @@ def main():
     deploy_parser.add_argument(*a_args, **a_kwargs)
     deploy_parser.add_argument(*c_args, **c_kwargs)
     deploy_parser.add_argument(*d_args, **d_kwargs)
+    deploy_parser.add_argument(*sf_args, **sf_kwargs)
     deploy_parser.add_argument(*l_args, **l_kwargs)
     deploy_parser.add_argument(*p_args, **p_kwargs)
     deploy_parser.set_defaults(func=deploy)

--- a/lamvery/config.py
+++ b/lamvery/config.py
@@ -88,6 +88,11 @@ class Config:
         else:
             return os.path.basename(os.getcwd())
 
+    def get_function_filename(self):
+        runtimes = { "python2.7": "py", "nodejs": "js" }
+        ext = runtimes.get(self.get_configuration().get('runtime'), "py")
+        return '{}.{}'.format(self.get_configuration().get('handler').split('.')[0], ext)
+
     def get_archive_name(self):
         return '{}.zip'.format(self.get_function_name())
 

--- a/tests/lamvery/actions/archive_test.py
+++ b/tests/lamvery/actions/archive_test.py
@@ -12,6 +12,7 @@ def default_args():
     args.conf_file = '.lamvery.yml'
     args.dry_run = True
     args.no_libs = False
+    args.single_file = False
     return args
 
 class ArchiveActionTestCase(TestCase):
@@ -24,6 +25,7 @@ class ArchiveActionTestCase(TestCase):
         action = ArchiveAction(default_args())
         action._config = Mock()
         action._config.get_archive_name = Mock(return_value='test.zip')
+        action._config.get_function_filename = Mock(return_value='test.py')
         action._config.generate_lambda_secret = Mock(return_value={})
         action._config.get_exclude = Mock(return_value=[])
         action.action()

--- a/tests/lamvery/actions/deploy_test.py
+++ b/tests/lamvery/actions/deploy_test.py
@@ -12,6 +12,7 @@ def default_args():
     args.dry_run = True
     args.publish = True
     args.no_libs = False
+    args.single_file = False
 
     return args
 
@@ -42,6 +43,14 @@ class DeployActionTestCase(TestCase):
         args.publish = True
         c.get_function_conf = Mock(return_value={'foo': 'bar'})
         action.get_client = Mock(return_value=c)
+        action.action()
+
+        # Single File
+        args = default_args()
+        args.single_file = True
+        action = DeployAction(args)
+        action._print_conf_diff = Mock()
+        action._print_capacity = Mock()
         action.action()
 
     def test_print_capacity(self):

--- a/tests/lamvery/config_test.py
+++ b/tests/lamvery/config_test.py
@@ -35,6 +35,8 @@ exclude:
 - ^bar
 """
 
+NODE_CONF = DEFAULT_CONF.replace('python2.7', 'nodejs')
+
 class FunctionsTestCase(TestCase):
 
     def test_represent_odict(self):
@@ -73,6 +75,16 @@ class ConfigTestCase(TestCase):
         eq_(config.get_function_name(), 'test_lambda_function')
         config = Config('/foo/bar')
         eq_(config.get_function_name(), os.path.basename(os.getcwd()))
+
+    def test_get_function_filename(self):
+        config = Config(self.conf_file)
+        eq_(config.get_function_filename(), 'lambda_function.py')
+
+        open(self.conf_file, 'w').write(NODE_CONF)
+        config = Config(self.conf_file)
+        runtime = config.get_configuration().get('runtime')
+        eq_(runtime, 'nodejs')
+        eq_(config.get_function_filename(), 'lambda_function.js')
 
     def test_get_archive_name(self):
         config = Config(self.conf_file)


### PR DESCRIPTION
Adds support to upload a single lambda function file, so users can do inline editing (for quick testing) in the AWS Management Console.