### PR TITLE
Improvement and bugfix for the feature of CloudWatch Events

### DIFF
--- a/.lamvery.event.yml
+++ b/.lamvery.event.yml
@@ -1,4 +1,5 @@
-- rule: sample-rule-name
+rules:
+- name: sample-rule-name
   description: This is a sample CloudWatchEvent
   schedule: rate(5 minutes)
   targets:

--- a/.lamvery.event.yml
+++ b/.lamvery.event.yml
@@ -3,9 +3,9 @@ rules:
   description: This is a sample CloudWatchEvent
   schedule: rate(5 minutes)
   targets:
-  - id: <unique-target-id>
+  - id: sample-target-1
     input:
       this:
       - is: a
       - sample: input
-    input_path: json.path.format
+#    input_path: json.path.format

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ lamvery decrypt -n <secret-name>
 - Apply CloudWatch Events setting
 
 ```sh
-lamvery events [-k]
+lamvery events [-k] [-a <alias>]
 ```
 
 ### invoke
@@ -256,7 +256,7 @@ lamvery logs [-f] [-F <filter>] [-s <start-time-string>] [-i <interval-seconds>]
 ## Options
 
 ### `-a` or `--alias`  
-This option is needed by the `deploy`,`set-alias`,`invoke`,`rollback` commands.  
+This option is needed by the `deploy`,`set-alias`,`invoke`,`rollback`,`events` commands.  
 Alias for a version of the function.
 
 ### `-c` or `--conf-file`  

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ The VPC configurations for the function to access resources in your VPC.
 ## CloudWatch Events settings (deafult: `.lamvery.event.yml`)
 
 ```yml
-- rule: foo
+rules:
+- name: foo
   description: bar
   schedule: 'rate(5 minutes)'
   targets:
@@ -116,28 +117,30 @@ The VPC configurations for the function to access resources in your VPC.
       - sample: input
 ```
 
-### rule  
+### rules
+CloudWatch Event Rules.
+
+- NAME  
 The name of CloudWatch Event Rule.
 
-### description  
+- description  
 The description of CloudWatch Event Rule.
 
-### schedule  
+- schedule  
 The schedule expression of CloudWatch Event Rule.
 
-### disabled  
+- disabled  
 When this setting is true, change the state of CloudWatch Event Rule to `DISABLED`.  
 default: `false`
 
-### targets  
+- targets  
 The targets of CloudWatch Event Rule.
-
-- id  
-The unique target assignment ID.
-- input  
-Arguments passed to the target.
-- input_path  
-The value of the JSONPath that is used for extracting part of the matched event when passing it to the target.
+  - id  
+  The unique target assignment ID.
+  - input  
+  Arguments passed to the target.
+  - input_path  
+  The value of the JSONPath that is used for extracting part of the matched event when passing it to the target.
 
 *`input` and `input_path` are mutually-exclusive and optional parameters of a target.*
 

--- a/lamvery/actions/base.py
+++ b/lamvery/actions/base.py
@@ -20,6 +20,7 @@ class BaseAction:
     def __init__(self, args):
         self._config = Config(args.conf_file)
         self._dry_run = False
+        self._alias = args.alias
 
         logger_name = 'lamvery'
         if hasattr(args, 'dry_run'):
@@ -50,6 +51,11 @@ class BaseAction:
 
     def get_logs_client(self):
         return self._get_client(LogsClient)
+
+    def get_alias_name(self):
+        if self._alias is not None:
+            return self._alias
+        return self._config.get_default_alias()
 
     def _get_diff(self, remote, local, keys):
         diff = {}

--- a/lamvery/actions/events.py
+++ b/lamvery/actions/events.py
@@ -27,7 +27,7 @@ class EventsAction(BaseAction):
         lambda_client = self.get_lambda_client()
         events_client = self.get_events_client()
         func_name = self._config.get_function_name()
-        conf = lambda_client.get_function_conf(func_name)
+        conf = lambda_client.get_function_conf(func_name, self.get_alias_name())
 
         if len(conf) == 0:
             msg = '"{}" function is not exists. Please `deploy` at first.'.format(func_name)

--- a/lamvery/actions/set_alias.py
+++ b/lamvery/actions/set_alias.py
@@ -7,8 +7,7 @@ class SetAliasAction(BaseAction):
 
     def __init__(self, args):
         super(SetAliasAction, self).__init__(args)
-        self._alias = args.alias
-        
+
         if hasattr(args, 'target'):
             self._target = args.target
         else:
@@ -41,11 +40,6 @@ class SetAliasAction(BaseAction):
         self._logger.warn(
             '[Alias] {name}: {cur} -> {new}'.format(
                 name=name, cur=current.get('FunctionVersion'), new=version))
-
-    def get_alias_name(self):
-        if self._alias is not None:
-            return self._alias
-        return self._config.get_default_alias()
 
     def get_version(self, function):
         version = '$LATEST'

--- a/lamvery/cli.py
+++ b/lamvery/cli.py
@@ -211,6 +211,7 @@ def main():
     events_parser = subparsers.add_parser(
         'events',
         help='Configure all events of CloudWatchEvents using the function')
+    events_parser.add_argument(*alias_args, **alias_kwargs)
     events_parser.add_argument(*conf_file_args, **conf_file_kwargs)
     events_parser.add_argument(*dry_run_args, **dry_run_kwargs)
     events_parser.add_argument(*keep_empty_args, **keep_empty_kwargs)

--- a/lamvery/clients/events.py
+++ b/lamvery/clients/events.py
@@ -43,7 +43,7 @@ class EventsClient(BaseClient):
             return {}
         else:
             kwargs = {}
-            kwargs['Name'] = rule['rule']
+            kwargs['Name'] = rule['name']
             kwargs['State'] = rule.get('state', 'ENABLED')
 
             if rule.get('description') is not None:

--- a/lamvery/clients/function.py
+++ b/lamvery/clients/function.py
@@ -13,10 +13,15 @@ class LambdaClient(BaseClient):
         super(LambdaClient, self).__init__(*args, **kwargs)
         self._lambda = self._session.client('lambda')
 
-    def get_function_conf(self, name):
+    def get_function_conf(self, name, alias=None):
         try:
-            res = self._lambda.get_function(
-                FunctionName=name)
+            kwargs = {}
+            kwargs['FunctionName'] = name
+
+            if alias is not None:
+                kwargs['Qualifier'] = alias
+
+            res = self._lambda.get_function(**kwargs)
             return res['Configuration']
         except botocore.exceptions.ClientError:
             return {}

--- a/lamvery/config.py
+++ b/lamvery/config.py
@@ -122,7 +122,7 @@ class Config:
             for e in events:
                 e['name'] = e['rule']
                 rules.append(e)
-                
+
             return {'rules': rules}
 
         return events

--- a/lamvery/config.py
+++ b/lamvery/config.py
@@ -115,7 +115,16 @@ class Config:
     def get_events(self):
         events = self.load_events()
         if events is None:
-            return []
+            return {'rules': []}
+
+        if isinstance(events, list):
+            rules = []
+            for e in events:
+                e['name'] = e['rule']
+                rules.append(e)
+                
+            return {'rules': rules}
+
         return events
 
     def get_default_alias(self):
@@ -193,11 +202,11 @@ class Config:
                 ('input', {'this': [{'is': 'a'}, {'sample': 'input'}]},),
                 ('input_path', 'json.path.format',)])]
         event = OrderedDict()
-        event['rule'] = 'sample-rule-name'
+        event['name'] = 'sample-rule-name'
         event['description'] = 'This is a sample CloudWatchEvent'
         event['schedule'] = 'rate(5 minutes)'
         event['targets'] = targets
-        init_events = [event]
+        init_events = {'rules': [event]}
 
         return init_events
 

--- a/tests/lamvery/actions/base_test.py
+++ b/tests/lamvery/actions/base_test.py
@@ -12,6 +12,7 @@ def default_args():
     args = Mock()
     args.conf_file = '.lamvery.yml'
     args.dry_run = True
+    args.alias = None
     return args
 
 
@@ -62,3 +63,11 @@ class BaseActionTestCase(TestCase):
         }
         action = TestAction(default_args())
         action._print_diff('test', remote, local, CONF_DIFF_KEYS)
+
+    def test_get_alias_name(self):
+        action = TestAction(default_args())
+        eq_(action.get_alias_name(), 'test')
+        args = default_args()
+        args.alias = 'foo'
+        action = TestAction(args)
+        eq_(action.get_alias_name(), 'foo')

--- a/tests/lamvery/actions/events_test.py
+++ b/tests/lamvery/actions/events_test.py
@@ -41,7 +41,7 @@ class EventsActionTestCase(TestCase):
             action._get_client = Mock(return_value=c)
             action._put_rules(
                 remote=[{'Name': 'bar'}],
-                local=[{'rule': 'foo'}, {'rule': 'bar'}],
+                local=[{'name': 'foo'}, {'name': 'bar'}],
                 function='baz')
 
     def test_convert_state(self):
@@ -51,13 +51,13 @@ class EventsActionTestCase(TestCase):
 
     def test_search_rule(self):
         action = EventsAction(default_args())
-        eq_(action._search_rule([{'Name': 'foo'}, {'rule': 'bar'}], 'bar'), {'rule': 'bar'})
-        eq_(action._search_rule([{'Name': 'foo'}, {'rule': 'bar'}], 'baz'), {})
+        eq_(action._search_rule([{'Name': 'foo'}, {'name': 'bar'}], 'bar'), {'name': 'bar'})
+        eq_(action._search_rule([{'Name': 'foo'}, {'name': 'bar'}], 'baz'), {})
 
     def test_exist_rule(self):
         action = EventsAction(default_args())
-        eq_(action._exist_rule([{'Name': 'foo'}, {'rule': 'bar'}], 'bar'), True)
-        eq_(action._exist_rule([{'Name': 'foo'}, {'rule': 'bar'}], 'baz'), False)
+        eq_(action._exist_rule([{'Name': 'foo'}, {'name': 'bar'}], 'bar'), True)
+        eq_(action._exist_rule([{'Name': 'foo'}, {'name': 'bar'}], 'baz'), False)
 
     def test_exist_target(self):
         action = EventsAction(default_args())
@@ -69,8 +69,8 @@ class EventsActionTestCase(TestCase):
             c.get_targets_by_rule = Mock(return_value=[{'Id': 'baz'}])
             action = EventsAction(default_args())
             local = [
-                {'rule': 'foo', 'targets': [{'id': 'baz'}]},
-                {'rule': 'bar', 'targets': [{'id': 'qux'}]}
+                {'name': 'foo', 'targets': [{'id': 'baz'}]},
+                {'name': 'bar', 'targets': [{'id': 'qux'}]}
             ]
             action._get_client = Mock(return_value=c)
             action._put_targets(local=local, arn='baz')
@@ -82,11 +82,11 @@ class EventsActionTestCase(TestCase):
             action._get_client = Mock(return_value=c)
             action._clean(
                 remote=[{'Name': 'bar'}],
-                local=[{'rule': 'foo', 'targets': []}, {'rule': 'bar', 'targets': []}],
+                local=[{'name': 'foo', 'targets': []}, {'name': 'bar', 'targets': []}],
                 arn='baz',
                 function='qux')
             action._clean(
                 remote=[{'Name': 'bar'}],
-                local=[{'rule': 'foo', 'targets': []}],
+                local=[{'name': 'foo', 'targets': []}],
                 arn='baz',
                 function='qux')

--- a/tests/lamvery/actions/set_alias_test.py
+++ b/tests/lamvery/actions/set_alias_test.py
@@ -57,14 +57,6 @@ class SetAliasActionTestCase(TestCase):
         action = SetAliasAction(default_args())
         action._print_alias_diff('name', {'FunctionVersion': 1}, 2)
 
-    def test_get_alias_name(self):
-        action = SetAliasAction(default_args())
-        eq_(action.get_alias_name(), 'test')
-        args = default_args()
-        args.alias = 'foo'
-        action = SetAliasAction(args)
-        eq_(action.get_alias_name(), 'foo')
-
     def test_get_version(self):
         action = SetAliasAction(default_args())
         eq_(action.get_version('foo'), '$LATEST')

--- a/tests/lamvery/clients/events_test.py
+++ b/tests/lamvery/clients/events_test.py
@@ -31,13 +31,13 @@ class EventsClientTestCase(TestCase):
 
     def test_put_rule(self):
         rule = {
-            'rule': 'foo',
+            'name': 'foo',
             'description': 'bar',
             'pattern': 'baz',
             'schedule': 'qux'}
         ok_(self.client.put_rule(rule) != {})
         client = EventsClient(region='us-east-1', profile=None, dry_run=True)
-        eq_(client.put_rule({'rule': 'foo'}), {})
+        eq_(client.put_rule({'name': 'foo'}), {})
 
     def test_put_targets(self):
         self.client.put_targets(

--- a/tests/lamvery/clients/function_test.py
+++ b/tests/lamvery/clients/function_test.py
@@ -31,7 +31,7 @@ class LambdaClientTestCase(TestCase):
     def test_get_function_conf(self):
         self.client._lambda.get_function = Mock(
             return_value={'Configuration': 'foo'})
-        eq_(self.client.get_function_conf('test'), 'foo')
+        eq_(self.client.get_function_conf('test', 'alias'), 'foo')
         self.client._lambda.get_function = Mock(
             side_effect=botocore.exceptions.ClientError({'Error': {}}, 'bar'))
         eq_(self.client.get_function_conf('test'), {})

--- a/tests/lamvery/config_test.py
+++ b/tests/lamvery/config_test.py
@@ -174,7 +174,7 @@ class ConfigTestCase(TestCase):
     def test_get_default_events(self):
         config = Config(self.conf_file)
         eq_(
-            config.get_default_events().pop().get('rule'),
+            config.get_default_events().get('rules').pop().get('name'),
             'sample-rule-name')
 
     def test_get_default_secret(self):
@@ -208,6 +208,8 @@ class ConfigTestCase(TestCase):
 
     def test_get_events(self):
         config = Config(self.conf_file)
-        eq_(config.get_events().pop().get('schedule'), 'rate(5 minutes)')
+        eq_(config.get_events().get('rules').pop().get('schedule'), 'rate(5 minutes)')
         config.load_events = Mock(return_value=None)
-        eq_(config.get_events(), [])
+        eq_(config.get_events(), {'rules': []})
+        config.load_events = Mock(return_value=[{'rule': 'foo'}])
+        eq_(config.get_events(), {'rules': [{'rule': 'foo', 'name': 'foo'}]})


### PR DESCRIPTION
- Change the format of the event configuration file
- Use ARN of the alias to the event targets (Previously, It was `$LATEST` by default)