### PR TITLE
Adding api and hook config to default excludes

### DIFF
--- a/lamvery/config.py
+++ b/lamvery/config.py
@@ -267,6 +267,8 @@ class Config:
     def get_default_exclude(self):
         return [
             '^{}$'.format(re.escape(self._file)),
+            '^{}$'.format(re.escape(self.get_api_file())),
+            '^{}$'.format(re.escape(self.get_hook_file())),
             '^{}$'.format(re.escape(self.get_event_file())),
             '^{}$'.format(re.escape(self.get_secret_file())),
             '^{}$'.format(re.escape(self.get_exclude_file()))]


### PR DESCRIPTION
I've noticed that the default exclude doesn't prevent the api and hook config files from being included in the zip. If this isn't intentional, this PR adds them. Thanks!