### PR TITLE
Integrate API Gateway without api-id option

### DIFF
--- a/lamvery/actions/api.py
+++ b/lamvery/actions/api.py
@@ -93,11 +93,13 @@ class ApiAction(BaseAction):
         if not self._no_integrate:
             api_conf = self._integrate_aws(api_conf, stage, cors)
 
-        self._print_conf_diff(
-            api_conf, self._get_remote_configuration(client, api_id, stage))
+        if api_id is not None:
+            self._print_conf_diff(
+                api_conf, self._get_remote_configuration(client, api_id, stage))
 
         if not self._dry_run:
             ret = self._apply_api(client, api_id, api_conf)
+            if api_id is None: api_id = ret['id']
 
             if self._write_id:
                 self._config.save_api_id(ret['id'])

--- a/lamvery/actions/api.py
+++ b/lamvery/actions/api.py
@@ -99,7 +99,8 @@ class ApiAction(BaseAction):
 
         if not self._dry_run:
             ret = self._apply_api(client, api_id, api_conf)
-            if api_id is None: api_id = ret['id']
+            if api_id is None:
+                api_id = ret['id']
 
             if self._write_id:
                 self._config.save_api_id(ret['id'])


### PR DESCRIPTION
Hello @marcy-terui,

I'm using `lamvery` now. It's very cool tool!
but I could not invoke lambda function via API-GW at first time. 
Maybe, in generally, we have to fill parameter `api_id` in `.lamvery.api.yml`.
But in some case, I'd like to deploy api-gw without `api_id`.

So, At first, I will send you this PullRequest as a sample to use integrated api_id instead of `api_id` in `.lamvery.api.yml`.

If you have something, please reply me.
Thanks.
