### PR TITLE
pass `['Environment']['Variables']` to create/update function from config

### DIFF
--- a/lamvery/clients/function.py
+++ b/lamvery/clients/function.py
@@ -37,7 +37,7 @@ class LambdaClient(BaseClient):
 
         if conf.get('environment_variables'):
             kwargs['Environment'] = {'Variables': {}}
-            kwargs['Environment']['Variables'] = conf.get('environment_variables')
+            kwargs['Environment']['Variables'] = conf['environment_variables']
 
         description = conf.get('description')
         if description is not None:
@@ -92,7 +92,7 @@ class LambdaClient(BaseClient):
 
         if conf.get('environment_variables'):
             kwargs['Environment'] = {'Variables': {}}
-            kwargs['Environment']['Variables'] = conf.get('environment_variables')
+            kwargs['Environment']['Variables'] = conf['environment_variables']
 
         vpc_config = conf.get('vpc_config')
         if vpc_config is not None:

--- a/lamvery/clients/function.py
+++ b/lamvery/clients/function.py
@@ -35,6 +35,10 @@ class LambdaClient(BaseClient):
         kwargs['Code'] = {'ZipFile': zipfile.read()}
         kwargs['Publish'] = publish
 
+        if conf.get('environment_variables'):
+            kwargs['Environment'] = {'Variables': {}}
+            kwargs['Environment']['Variables'] = conf.get('environment_variables')
+
         description = conf.get('description')
         if description is not None:
             kwargs['Description'] = description
@@ -85,6 +89,10 @@ class LambdaClient(BaseClient):
         memory_size = conf.get('memory_size')
         if memory_size is not None:
             kwargs['MemorySize'] = memory_size
+
+        if conf.get('environment_variables'):
+            kwargs['Environment'] = {'Variables': {}}
+            kwargs['Environment']['Variables'] = conf.get('environment_variables')
 
         vpc_config = conf.get('vpc_config')
         if vpc_config is not None:

--- a/lamvery/clients/function.py
+++ b/lamvery/clients/function.py
@@ -35,10 +35,6 @@ class LambdaClient(BaseClient):
         kwargs['Code'] = {'ZipFile': zipfile.read()}
         kwargs['Publish'] = publish
 
-        if conf.get('environment_variables'):
-            kwargs['Environment'] = {'Variables': {}}
-            kwargs['Environment']['Variables'] = conf['environment_variables']
-
         description = conf.get('description')
         if description is not None:
             kwargs['Description'] = description
@@ -54,6 +50,11 @@ class LambdaClient(BaseClient):
         vpc_config = conf.get('vpc_config')
         if vpc_config is not None:
             kwargs['VpcConfig'] = self._build_vpc_config(vpc_config)
+
+        environment_variables = conf.get('environment_variables')
+        if environment_variables is not None:
+            kwargs['Environment'] = {'Variables': {}}
+            kwargs['Environment']['Variables'] = conf['environment_variables']
 
         if not self._dry_run:
             self._lambda.create_function(**kwargs)
@@ -90,13 +91,14 @@ class LambdaClient(BaseClient):
         if memory_size is not None:
             kwargs['MemorySize'] = memory_size
 
-        if conf.get('environment_variables'):
-            kwargs['Environment'] = {'Variables': {}}
-            kwargs['Environment']['Variables'] = conf['environment_variables']
-
         vpc_config = conf.get('vpc_config')
         if vpc_config is not None:
             kwargs['VpcConfig'] = self._build_vpc_config(vpc_config)
+
+        environment_variables = conf.get('environment_variables')
+        if environment_variables is not None:
+            kwargs['Environment'] = {'Variables': {}}
+            kwargs['Environment']['Variables'] = conf['environment_variables']
 
         if not self._dry_run:
             self._lambda.update_function_configuration(**kwargs)


### PR DESCRIPTION
Lambda側設定のEnvironment variablesを付け外しします。

config例は次の通りです。

```
configuration:
  name: env-test
  runtime: python2.7
  ....
  memory_size: 128
  environment_variables: null
    MYENV: foobar
    YOUENV: AQECAHjMznfzMA3JOt3.....
```

省略したらLatestを引き継ぐので、消す場合は次のようにします。

```
  environment_variables: {}
```
