### PR TITLE
pin jinja2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3>=1.4.2
 botocore>=1.4.88
-Jinja2
+Jinja2==2.8.1
 PyYAML
 termcolor
 parsedatetime


### PR DESCRIPTION
recently, lamvery would not compile

https://gist.github.com/ijin/1f966831894dad80c9d147b98eeec858

In addition, on running `python setup.py install` locally, jinja2 gave some errors.
```
Running Jinja2-2.9.4/setup.py -q bdist_egg --dist-dir /tmp/easy_install-rcBfOJ/Jinja2-2.9.4/egg-dist-tmp-ZGzjgU
warning: no files found matching 'run-tests.py'
warning: no files found matching '*' under directory 'custom_fixers'
warning: no files found matching '*' under directory 'jinja2/testsuite/res'
warning: no previously-included files matching '*' found under directory 'docs/_build'
warning: no previously-included files matching '*.pyc' found under directory 'jinja2'
warning: no previously-included files matching '*.pyc' found under directory 'docs'
warning: no previously-included files matching '*.pyo' found under directory 'jinja2'
warning: no previously-included files matching '*.pyo' found under directory 'docs'
  File "build/bdist.linux-x86_64/egg/jinja2/asyncsupport.py", line 22
    async def concat_async(async_gen):
            ^
SyntaxError: invalid syntax

  File "build/bdist.linux-x86_64/egg/jinja2/asyncfilters.py", line 7
    async def auto_to_seq(value):
            ^
SyntaxError: invalid syntax

  File "/home/ubuntu/.venv/lib/python2.7/site-packages/Jinja2-2.9.4-py2.7.egg/jinja2/asyncsupport.py", line 22
    async def concat_async(async_gen):
            ^
SyntaxError: invalid syntax

  File "/home/ubuntu/.venv/lib/python2.7/site-packages/Jinja2-2.9.4-py2.7.egg/jinja2/asyncfilters.py", line 7
    async def auto_to_seq(value):
            ^
SyntaxError: invalid syntax
```

pinning jinja2 to a lower version (2.8.1) resolves this.