### PR TITLE
nodejs4.3 runtime support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,13 @@ coverage.xml
 
 .venv
 *.zip
+### https://raw.github.com/github/gitignore/be3333655bffe9507d66cc864aee95ed6052b4ed/Global/vim.gitignore
+
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist
+*~
+
+

--- a/lamvery/clients/function.py
+++ b/lamvery/clients/function.py
@@ -2,6 +2,7 @@
 
 import botocore
 import hashlib
+import lamvery.config
 
 from lamvery.clients.base import BaseClient
 from lamvery.utils import previous_alias
@@ -26,10 +27,13 @@ class LambdaClient(BaseClient):
         except botocore.exceptions.ClientError:
             return {}
 
+    def _get_runtime(self, conf):
+        return lamvery.config.DEFAULT_RUNTIME_NODE_JS if conf['runtime'] == 'nodejs' else conf['runtime']
+
     def create_function(self, zipfile, conf, publish):
         kwargs = {}
         kwargs['FunctionName'] = conf['name']
-        kwargs['Runtime'] = conf['runtime']
+        kwargs['Runtime'] = self._get_runtime(conf)
         kwargs['Role'] = conf['role']
         kwargs['Handler'] = conf['handler']
         kwargs['Code'] = {'ZipFile': zipfile.read()}

--- a/lamvery/clients/function.py
+++ b/lamvery/clients/function.py
@@ -80,6 +80,7 @@ class LambdaClient(BaseClient):
     def update_function_conf(self, conf):
         kwargs = {}
         kwargs['FunctionName'] = conf['name']
+        kwargs['Runtime'] = self._get_runtime(conf)
         kwargs['Role'] = conf['role']
         kwargs['Handler'] = conf['handler']
 

--- a/lamvery/config.py
+++ b/lamvery/config.py
@@ -11,10 +11,12 @@ from lamvery.log import get_logger
 
 RUNTIME_PY_27 = 'python2.7'
 RUNTIME_NODE_JS = 'nodejs'
+RUNTIME_NODE_JS_43 = 'nodejs4.3'
 
 RUNTIME_AND_EXTENSION = {
     RUNTIME_PY_27: 'py',
-    RUNTIME_NODE_JS: 'js'
+    RUNTIME_NODE_JS: 'js',
+    RUNTIME_NODE_JS_43: 'js'
 }
 
 

--- a/lamvery/config.py
+++ b/lamvery/config.py
@@ -12,6 +12,7 @@ from lamvery.log import get_logger
 RUNTIME_PY_27 = 'python2.7'
 RUNTIME_NODE_JS = 'nodejs'
 RUNTIME_NODE_JS_43 = 'nodejs4.3'
+DEFAULT_RUNTIME_NODE_JS = RUNTIME_NODE_JS_43
 
 RUNTIME_AND_EXTENSION = {
     RUNTIME_PY_27: 'py',

--- a/lamvery/config.py
+++ b/lamvery/config.py
@@ -121,7 +121,10 @@ class Config:
         return txt
 
     def get_configuration(self):
-        return self.load_conf().get('configuration')
+        config = self.load_conf().get('configuration')
+        if config['runtime'] == 'nodejs':
+            config['runtime'] = DEFAULT_RUNTIME_NODE_JS
+        return config
 
     def get_vpc_configuration(self):
         vpc_config = self.get_configuration().get('vpc_config')

--- a/tests/lamvery/clients/function_test.py
+++ b/tests/lamvery/clients/function_test.py
@@ -21,6 +21,9 @@ TEST_CONF = {
     }
 }
 
+NODE_CONF = dict(TEST_CONF, runtime='nodejs')
+NODE43_CONF = dict(TEST_CONF, runtime='nodejs4.3')
+
 
 class LambdaClientTestCase(TestCase):
 
@@ -35,6 +38,11 @@ class LambdaClientTestCase(TestCase):
         self.client._lambda.get_function = Mock(
             side_effect=botocore.exceptions.ClientError({'Error': {}}, 'bar'))
         eq_(self.client.get_function_conf('test'), {})
+
+    def test_get_runtime(self):
+        eq_(self.client._get_runtime(TEST_CONF), 'python2.7')
+        eq_(self.client._get_runtime(NODE_CONF), 'nodejs4.3')
+        eq_(self.client._get_runtime(NODE43_CONF), 'nodejs4.3')
 
     def test_create_function(self):
         self.client.create_function(Mock(), TEST_CONF, True)

--- a/tests/lamvery/config_test.py
+++ b/tests/lamvery/config_test.py
@@ -160,7 +160,7 @@ class ConfigTestCase(TestCase):
         open(self.conf_file, 'w').write(NODE_CONF)
         config = Config(self.conf_file)
         runtime = config.get_configuration().get('runtime')
-        eq_(runtime, 'nodejs')
+        eq_(runtime, 'nodejs4.3')
 
         open(self.conf_file, 'w').write(NODE43_CONF)
         config = Config(self.conf_file)

--- a/tests/lamvery/config_test.py
+++ b/tests/lamvery/config_test.py
@@ -89,6 +89,7 @@ configuration:
 """
 
 NODE_CONF = DEFAULT_CONF.replace('python2.7', 'nodejs')
+NODE43_CONF = DEFAULT_CONF.replace('python2.7', 'nodejs4.3')
 
 
 class FunctionsTestCase(TestCase):
@@ -156,6 +157,16 @@ class ConfigTestCase(TestCase):
         config = Config(self.conf_file)
         eq_(config.get_runtime(), 'python2.7')
 
+        open(self.conf_file, 'w').write(NODE_CONF)
+        config = Config(self.conf_file)
+        runtime = config.get_configuration().get('runtime')
+        eq_(runtime, 'nodejs')
+
+        open(self.conf_file, 'w').write(NODE43_CONF)
+        config = Config(self.conf_file)
+        runtime = config.get_configuration().get('runtime')
+        eq_(runtime, 'nodejs4.3')
+
     def test_get_handler(self):
         config = Config(self.conf_file)
         eq_(config.get_handler(), 'lambda_function.lambda_handler')
@@ -199,8 +210,10 @@ class ConfigTestCase(TestCase):
 
         open(self.conf_file, 'w').write(NODE_CONF)
         config = Config(self.conf_file)
-        runtime = config.get_configuration().get('runtime')
-        eq_(runtime, 'nodejs')
+        eq_(config.get_function_filename(), 'lambda_function.js')
+
+        open(self.conf_file, 'w').write(NODE43_CONF)
+        config = Config(self.conf_file)
         eq_(config.get_function_filename(), 'lambda_function.js')
 
     def test_get_archive_name(self):


### PR DESCRIPTION
Support for nodejs0.10 has been [deprecated](https://forums.aws.amazon.com/ann.jspa?annID=4345) in Lambda. This adds the following:

- nodejs4.3 runtime support
- overrides `nodejs` with `nodejs4.3` on function create/update

Overriding `nodejs` makes it easier to transition to the newer runtime without having to edit current `.lamvery.yml` files.